### PR TITLE
Add build and push container functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,36 +9,18 @@ COLOR_RED = \033[31m
 
 PROJECT := huskyCI-dashboard
 
-## Installs locally using install command.
-install:
-	yarn install
 
 ## Builds static files from react app.
 build:
 	yarn build
 
-## Runs locally using start command.
-run:
-	yarn start
-	
+## Creates a container image based on most recent dashboard code
+build-container:
+	docker build . -t huskyci/dashboard:latest
+
 ## Checks for vulnerabilities using audit command.
 check-sec:
 	yarn audit
-
-## Runs a full test into project.
-test: 
-	yarn test
-
-## Creates a container image based on most recent dashboard code
-build-container: 
-	docker build . -t huskyci/dashboard
-
-## Starts huskyci/dashboard container
-start-container: 
-	docker run -p 8080:80 huskyci/dashboard
-
-## Builds and starts dashboard add using huskyci/dashboard container
-run-container: build-container start-container
 
 ## Shows this help message.
 help:
@@ -53,3 +35,27 @@ help:
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST) | sort
 	printf "\n"
+
+## Installs locally using install command.
+install:
+	yarn install
+
+## Push dashboard container to hub.docker
+push-container:
+	chmod +x push-container.sh
+	./push-container.sh
+
+## Runs locally using start command.
+run:
+	yarn start
+
+## Builds and starts dashboard add using huskyci/dashboard container
+run-container: build-container start-container
+
+## Runs a full test into project.
+test:
+	yarn test
+
+## Starts huskyci/dashboard container
+start-container:
+	docker run -p 8080:80 huskyci/dashboard

--- a/push-container.sh
+++ b/push-container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright 2019 Globo.com authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# This script will push huskyCI-dashboard container to docker hub
+#
+
+lastRelease=$(curl -s https://api.github.com/repos/globocom/huskyCI-dashboard/releases/latest | grep "tag_name" | awk -F '"' '{print $4}')
+docker tag huskyci/dashboard:latest huskyci/dashboard:$lastRelease
+docker push huskyci/dashboard:$lastRelease && docker push huskyci/dashboard:latest


### PR DESCRIPTION
This PR will add new functions to Makefile to turn the process of building and pushing a new dashboard container smother:

* ` build-container`: Creates locally a container image based on most recent dashboard code.
* `push-container` : Push dashboard container to hub.docker.