### PR TITLE
Add check for author array length.

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -82,10 +82,12 @@ class Dashboard extends Component {
     }
     if (huskyRoute === huskyCIAuthorRoute) {
       response.json().then((authorResultJSON) => {
-        const newNumAuthorsResult = authorResultJSON[0].totalAuthors;
-        const { numAuthors } = this.state;
-        if (!_.isEqual(numAuthors, newNumAuthorsResult)) {
-          this.setState({ numAuthors: newNumAuthorsResult });
+        if (Array.isArray(authorResultJSON) && authorResultJSON.length) {
+          const newNumAuthorsResult = authorResultJSON[0].totalAuthors;
+          const { numAuthors } = this.state;
+          if (!_.isEqual(numAuthors, newNumAuthorsResult)) {
+            this.setState({ numAuthors: newNumAuthorsResult });
+          }
         }
       });
     }


### PR DESCRIPTION
For some reason, the API would sometimes return a null array, i.e. `[]`.
This PR adds a check for that, preventing it from crashing the web interface.