### PR TITLE
dashboard.js|STYLE: fix y-axis minimum to 0

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -18,7 +18,7 @@ const styles = {
     height: 100,
   },
 };
-
+const snackDurationInMS = 5000
 const chartOptions = {
   legend: {
     display: false
@@ -396,7 +396,7 @@ class Dashboard extends Component {
         </Row>
         <SnackComponent
           open={snackOpen}
-          duration={5000}
+          duration={snackDurationInMS}
           onClose={this.closeSnack}
           variant={variantValue}
           message={snackMessage}

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -19,6 +19,19 @@ const styles = {
   },
 };
 
+const chartOptions = {
+  legend: {
+    display: false
+  },
+  scales: {
+    yAxes: [{
+      ticks: {
+        min: 0
+      }
+    }]
+  }
+}
+
 const huskyCIAPIAddress = process.env.REACT_APP_HUSKYCI_FE_API_ADDRESS;
 const huskyCIAuthorRoute = `${huskyCIAPIAddress}/stats/author`;
 const huskyCIAnalysisRoute = `${huskyCIAPIAddress}/stats/analysis`;
@@ -356,7 +369,7 @@ class Dashboard extends Component {
                 width={boxSizeWidth}
                 height={boxSizeHeight}
                 data={infoAnalysis}
-                legend={{ display: false }}
+                options={chartOptions}
               />
             </Paper>
           </div>
@@ -366,7 +379,7 @@ class Dashboard extends Component {
                 width={boxSizeWidth}
                 height={boxSizeHeight}
                 data={infoLanguages}
-                legend={{ display: false }}
+                options={chartOptions}
               />
             </Paper>
           </div>
@@ -376,14 +389,14 @@ class Dashboard extends Component {
                 width={boxSizeWidth}
                 height={boxSizeHeight}
                 data={infoContainers}
-                legend={{ display: false }}
+                options={chartOptions}
               />
             </Paper>
           </div>
         </Row>
         <SnackComponent
           open={snackOpen}
-          duration={null}
+          duration={5000}
           onClose={this.closeSnack}
           variant={variantValue}
           message={snackMessage}


### PR DESCRIPTION
This PR fixes the bar chart Y-axis minimum to 0 and sets the duration ( 5 seconds ) to make the snack bars to disappear.