### PR TITLE
Add history graph

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -53,5 +53,5 @@ license that can be found in the LICENSE file.
   color:#6e6e6e;
   font-size: 20px;
   width: 100%;
-  padding-top: 5%;
+  padding-top: 1%;
  }

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -1,5 +1,5 @@
 import { Paper } from "@material-ui/core";
-import { Bar, Doughnut, Pie } from "react-chartjs-2";
+import { Bar, Doughnut, Pie, Line } from "react-chartjs-2";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -30,10 +30,26 @@ const dounghnutChartDefaultOptions = {
   },
 };
 
+const lineChartDefaultOptions = {
+  legend: {
+    display: true,
+  },
+  scales: {
+    yAxes: [
+      {
+        ticks: {
+          min: 0,
+        },
+      },
+    ],
+  },
+};
+
 const GraphType = {
   Pie: "Pie",
   Doughnut: "Doughnut",
   Bar: "Bar",
+  Line: "Line",
 };
 
 const asDoughnut = ({
@@ -42,11 +58,17 @@ const asDoughnut = ({
   height,
   options = dounghnutChartDefaultOptions,
 }) => <Doughnut data={data} width={width} height={height} options={options} />;
+
 const asPie = ({ data, width, height, options = pieChartDefaultOptions }) => (
   <Pie data={data} width={width} height={height} options={options} />
 );
+
 const asBar = ({ data, width, height, options = barChartDefaultOptions }) => (
   <Bar data={data} width={width} height={height} options={options} />
+);
+
+const asLine = ({ data, width, height, options = lineChartDefaultOptions }) => (
+  <Line data={data} width={width} height={height / 7} options={options} />
 );
 
 const renderGraph = props => {
@@ -57,6 +79,8 @@ const renderGraph = props => {
       return asDoughnut({ ...props });
     case GraphType.Pie:
       return asPie({ ...props });
+    case GraphType.Line:
+      return asLine({ ...props });
     default:
       return asBar({ ...props });
   }


### PR DESCRIPTION
If approved, this PR will add a new graph into the huskyCI-dashboard: 

![image](https://user-images.githubusercontent.com/8943477/66867427-a62fbc80-ef71-11e9-8cf9-0d6cdb7264dc.png)

At this moment, the x-axis bar is hardcoded by the hour of the day. On future commits, we can work on letting users use filter for `today`, `yesterday`, `last7days`, `lastMonth` or `all`. 